### PR TITLE
Unify site typography

### DIFF
--- a/cenik.php
+++ b/cenik.php
@@ -1,6 +1,6 @@
 <?php include "header.php"; ?>
 
-        <h1 class="ruzova">Ceník</h1>
+        <h1>Ceník</h1>
 
         <p>
         Uvedené ceny <span class="zluta"><b>nezahrnují materiál</b></span> a jsou pouze orientační. Podle složitosti provedení mohou být až o 20 procent vyšší.

--- a/galerie.php
+++ b/galerie.php
@@ -1,6 +1,6 @@
 <?php include "header.php"; ?>
 
-        <h1 class="zluta">Galerie</h1>
+        <h1>Galerie</h1>
 
         <p>
         Několik obrázků mých prací:

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php include "header.php"; ?>
 
-        <h1 class="zelena">Vítám Vás</h1>
+        <h1>Vítám Vás</h1>
 
         <p>
         Vážený návštěvníku, vítám Vás na svých stránkách.

--- a/kontakt.php
+++ b/kontakt.php
@@ -1,6 +1,6 @@
 <?php include "header.php"; ?>
 
-        <h1 class="modra">Kontakt</h1>
+        <h1>Kontakt</h1>
 
         <p>
         <span class="zelena"><br><b>Provozovna Hrabyně</b></span>

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,18 @@
 body {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
   margin: 0;
   padding: 0;
   background: #fafafa;
-  color: #333;
+  color: #444;
+  font-size: 1.1rem;
   line-height: 1.6;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: normal;
+  color: inherit;
+  margin: 1rem 0;
 }
 
 .modern-header {
@@ -103,7 +111,9 @@ main {
   text-decoration: none;
 }
 
-.ruzova { color: #ed497b; }
-.zluta { color: #e2cf00; }
-.zelena { color: #93bd33; }
-.modra { color: #3393bd; }
+.ruzova,
+.zluta,
+.zelena,
+.modra {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- use Roboto font and slightly larger default size
- normalize all headings to rely on size instead of color or bold weight
- remove color classes from headings and neutralize color utility classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684edf2a40f48325868d9e80e0000f0c